### PR TITLE
Add more UINavigationController methods

### DIFF
--- a/DLRUIKit.podspec
+++ b/DLRUIKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "DLRUIKit"
-  s.version          = "1.2.2"
+  s.version          = "1.3.0"
   s.summary          = "A collection of UIKit categories."
   s.homepage         = "https://github.com/detroit-labs/dlr-uikit-ios"
   s.license          = 'MIT'

--- a/DLRUIKit.xcodeproj/project.pbxproj
+++ b/DLRUIKit.xcodeproj/project.pbxproj
@@ -28,6 +28,12 @@
 		4362BDC01A8ABA5900B3A89E /* UIDevice+DLR.h in Headers */ = {isa = PBXBuildFile; fileRef = 4362BDBE1A8ABA5900B3A89E /* UIDevice+DLR.h */; };
 		4362BDC11A8ABA5900B3A89E /* UIDevice+DLR.m in Sources */ = {isa = PBXBuildFile; fileRef = 4362BDBF1A8ABA5900B3A89E /* UIDevice+DLR.m */; };
 		4362BDC31A8AC0C400B3A89E /* UIDevice+DLRTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4362BDC21A8AC0C400B3A89E /* UIDevice+DLRTests.m */; };
+		4388EE101AF11DA400CD2140 /* UINavigationController+DLR.h in Headers */ = {isa = PBXBuildFile; fileRef = 4388EE0E1AF11DA400CD2140 /* UINavigationController+DLR.h */; };
+		4388EE111AF11DA400CD2140 /* UINavigationController+DLR.m in Sources */ = {isa = PBXBuildFile; fileRef = 4388EE0F1AF11DA400CD2140 /* UINavigationController+DLR.m */; };
+		4388EE131AF11DB700CD2140 /* UINavigationController+DLRTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4388EE121AF11DB700CD2140 /* UINavigationController+DLRTests.m */; };
+		4388EE161AF11E9100CD2140 /* UIViewController+DLRNavigationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4388EE141AF11E9100CD2140 /* UIViewController+DLRNavigationController.h */; };
+		4388EE171AF11E9100CD2140 /* UIViewController+DLRNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4388EE151AF11E9100CD2140 /* UIViewController+DLRNavigationController.m */; };
+		4388EE191AF11F0200CD2140 /* UIViewController+DLRNavigationControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4388EE181AF11F0200CD2140 /* UIViewController+DLRNavigationControllerTests.m */; };
 		439372ED1A851D8B00A552D5 /* DLRUIKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 439372EC1A851D8B00A552D5 /* DLRUIKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		439372F31A851D8B00A552D5 /* DLRUIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 439372E71A851D8B00A552D5 /* DLRUIKit.framework */; };
 		439373661A8521A800A552D5 /* UIApplication+DLRLocalNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 439373581A8521A800A552D5 /* UIApplication+DLRLocalNotifications.h */; };
@@ -112,6 +118,12 @@
 		4362BDBE1A8ABA5900B3A89E /* UIDevice+DLR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIDevice+DLR.h"; sourceTree = "<group>"; };
 		4362BDBF1A8ABA5900B3A89E /* UIDevice+DLR.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIDevice+DLR.m"; sourceTree = "<group>"; };
 		4362BDC21A8AC0C400B3A89E /* UIDevice+DLRTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIDevice+DLRTests.m"; sourceTree = "<group>"; };
+		4388EE0E1AF11DA400CD2140 /* UINavigationController+DLR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UINavigationController+DLR.h"; sourceTree = "<group>"; };
+		4388EE0F1AF11DA400CD2140 /* UINavigationController+DLR.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UINavigationController+DLR.m"; sourceTree = "<group>"; };
+		4388EE121AF11DB700CD2140 /* UINavigationController+DLRTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UINavigationController+DLRTests.m"; sourceTree = "<group>"; };
+		4388EE141AF11E9100CD2140 /* UIViewController+DLRNavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+DLRNavigationController.h"; sourceTree = "<group>"; };
+		4388EE151AF11E9100CD2140 /* UIViewController+DLRNavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+DLRNavigationController.m"; sourceTree = "<group>"; };
+		4388EE181AF11F0200CD2140 /* UIViewController+DLRNavigationControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+DLRNavigationControllerTests.m"; sourceTree = "<group>"; };
 		439372E71A851D8B00A552D5 /* DLRUIKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DLRUIKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		439372EB1A851D8B00A552D5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		439372EC1A851D8B00A552D5 /* DLRUIKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DLRUIKit.h; sourceTree = "<group>"; };
@@ -386,10 +398,14 @@
 				4362BDBF1A8ABA5900B3A89E /* UIDevice+DLR.m */,
 				4393735C1A8521A800A552D5 /* UIImage+DLR.h */,
 				4393735D1A8521A800A552D5 /* UIImage+DLR.m */,
+				4388EE0E1AF11DA400CD2140 /* UINavigationController+DLR.h */,
+				4388EE0F1AF11DA400CD2140 /* UINavigationController+DLR.m */,
 				4393735E1A8521A800A552D5 /* UIView+DLRLayoutConstraints.h */,
 				4393735F1A8521A800A552D5 /* UIView+DLRLayoutConstraints.m */,
 				439373601A8521A800A552D5 /* UIView+DLRRoundedCorners.h */,
 				439373611A8521A800A552D5 /* UIView+DLRRoundedCorners.m */,
+				4388EE141AF11E9100CD2140 /* UIViewController+DLRNavigationController.h */,
+				4388EE151AF11E9100CD2140 /* UIViewController+DLRNavigationController.m */,
 				439373621A8521A800A552D5 /* UIViewController+DLRParentViewController.h */,
 				439373631A8521A800A552D5 /* UIViewController+DLRParentViewController.m */,
 				439373641A8521A800A552D5 /* UIWebView+DLRViewport.h */,
@@ -407,8 +423,10 @@
 				439373761A85220F00A552D5 /* UIColor+DLRTests.m */,
 				4362BDC21A8AC0C400B3A89E /* UIDevice+DLRTests.m */,
 				439373771A85220F00A552D5 /* UIImage+DLRTests.m */,
+				4388EE121AF11DB700CD2140 /* UINavigationController+DLRTests.m */,
 				439373781A85220F00A552D5 /* UIView+DLRLayoutConstraintsTests.m */,
 				439373791A85220F00A552D5 /* UIView+DLRRoundedCornersTests.m */,
+				4388EE181AF11F0200CD2140 /* UIViewController+DLRNavigationControllerTests.m */,
 				4393737A1A85220F00A552D5 /* UIViewController+DLRParentViewControllerTests.m */,
 				4393737B1A85220F00A552D5 /* UIWebView+DLRViewportTests.m */,
 			);
@@ -436,6 +454,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4388EE161AF11E9100CD2140 /* UIViewController+DLRNavigationController.h in Headers */,
 				433C59FC1AC335BE0014EFB8 /* DLRLayoutConstraint.h in Headers */,
 				439372ED1A851D8B00A552D5 /* DLRUIKit.h in Headers */,
 				439373721A8521A800A552D5 /* UIWebView+DLRViewport.h in Headers */,
@@ -449,6 +468,7 @@
 				4393736E1A8521A800A552D5 /* UIView+DLRRoundedCorners.h in Headers */,
 				439373701A8521A800A552D5 /* UIViewController+DLRParentViewController.h in Headers */,
 				43B4C20D1A8C19C300680976 /* UIViewController+DLRStoryboardManager.h in Headers */,
+				4388EE101AF11DA400CD2140 /* UINavigationController+DLR.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -607,8 +627,10 @@
 				4393736D1A8521A800A552D5 /* UIView+DLRLayoutConstraints.m in Sources */,
 				4362BDC11A8ABA5900B3A89E /* UIDevice+DLR.m in Sources */,
 				4393736F1A8521A800A552D5 /* UIView+DLRRoundedCorners.m in Sources */,
+				4388EE171AF11E9100CD2140 /* UIViewController+DLRNavigationController.m in Sources */,
 				43B4C2131A8C1B2B00680976 /* DLRStoryboardManager.m in Sources */,
 				4393736B1A8521A800A552D5 /* UIImage+DLR.m in Sources */,
+				4388EE111AF11DA400CD2140 /* UINavigationController+DLR.m in Sources */,
 				439373731A8521A800A552D5 /* UIWebView+DLRViewport.m in Sources */,
 				439373691A8521A800A552D5 /* UIColor+DLR.m in Sources */,
 				439373671A8521A800A552D5 /* UIApplication+DLRLocalNotifications.m in Sources */,
@@ -620,11 +642,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				433C59EF1AC30B100014EFB8 /* UIViewController+DLRStoryboardManagerTests.m in Sources */,
+				4388EE131AF11DB700CD2140 /* UINavigationController+DLRTests.m in Sources */,
 				433C59F81AC311230014EFB8 /* DLRStoryboardManagerTests.m in Sources */,
 				433A87051A856455008CFA82 /* UIButton+DLRTests.m in Sources */,
 				4393737E1A85220F00A552D5 /* UIImage+DLRTests.m in Sources */,
 				4393737F1A85220F00A552D5 /* UIView+DLRLayoutConstraintsTests.m in Sources */,
 				4362BDC31A8AC0C400B3A89E /* UIDevice+DLRTests.m in Sources */,
+				4388EE191AF11F0200CD2140 /* UIViewController+DLRNavigationControllerTests.m in Sources */,
 				4393737D1A85220F00A552D5 /* UIColor+DLRTests.m in Sources */,
 				4393737C1A85220F00A552D5 /* UIApplication+DLRLocalNotificationsTests.m in Sources */,
 				439373821A85220F00A552D5 /* UIWebView+DLRViewportTests.m in Sources */,

--- a/DLRUIKit/source/UINavigationController+DLR.h
+++ b/DLRUIKit/source/UINavigationController+DLR.h
@@ -10,7 +10,9 @@
 
 @interface UINavigationController (DLR)
 
-/** Returns true if the passed view controller is the first view controller in the stack of view controllers. */
+/** Returns true if the passed view controller is the first view controller in the
+ stack of view controllers.  This can be helpful in determining if the
+ view controller needed to be popped or dismissed. */
 - (BOOL)dlr_isFirstViewController:(UIViewController *)viewController;
 
 @end

--- a/DLRUIKit/source/UINavigationController+DLR.h
+++ b/DLRUIKit/source/UINavigationController+DLR.h
@@ -1,0 +1,16 @@
+//
+//  UINavigationController+DLR.h
+//  DLRUIKit
+//
+//  Created by Nate Walczak on 4/29/15.
+//  Copyright (c) 2015 Detroit Labs, LLC. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UINavigationController (DLR)
+
+/** Returns true if the passed view controller is the first view controller in the stack of view controllers. */
+- (BOOL)dlr_isFirstViewController:(UIViewController *)viewController;
+
+@end

--- a/DLRUIKit/source/UINavigationController+DLR.m
+++ b/DLRUIKit/source/UINavigationController+DLR.m
@@ -1,0 +1,17 @@
+//
+//  UINavigationController+DLR.m
+//  DLRUIKit
+//
+//  Created by Nate Walczak on 4/29/15.
+//  Copyright (c) 2015 Detroit Labs, LLC. All rights reserved.
+//
+
+#import "UINavigationController+DLR.h"
+
+@implementation UINavigationController (DLR)
+
+- (BOOL)dlr_isFirstViewController:(UIViewController *)viewController {
+    return self.viewControllers.firstObject == viewController;
+}
+
+@end

--- a/DLRUIKit/source/UIViewController+DLRNavigationController.h
+++ b/DLRUIKit/source/UIViewController+DLRNavigationController.h
@@ -10,7 +10,8 @@
 
 @interface UIViewController (DLRNavigationController)
 
-/** Returns a new navigation controller instance with this view controller as the root view controller. */
+/** Returns a new navigation controller instance with this view controller as the
+ root view controller. */
 - (UINavigationController *)dlr_embedInsideNavigationController;
 
 @end

--- a/DLRUIKit/source/UIViewController+DLRNavigationController.h
+++ b/DLRUIKit/source/UIViewController+DLRNavigationController.h
@@ -1,0 +1,16 @@
+//
+//  UIViewController+DLRNavigationController.h
+//  DLRUIKit
+//
+//  Created by Nate Walczak on 4/29/15.
+//  Copyright (c) 2015 Detroit Labs, LLC. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIViewController (DLRNavigationController)
+
+/** Returns a new navigation controller instance with this view controller as the root view controller. */
+- (UINavigationController *)dlr_embedInsideNavigationController;
+
+@end

--- a/DLRUIKit/source/UIViewController+DLRNavigationController.m
+++ b/DLRUIKit/source/UIViewController+DLRNavigationController.m
@@ -1,0 +1,17 @@
+//
+//  UIViewController+DLRNavigationController.m
+//  DLRUIKit
+//
+//  Created by Nate Walczak on 4/29/15.
+//  Copyright (c) 2015 Detroit Labs, LLC. All rights reserved.
+//
+
+#import "UIViewController+DLRNavigationController.h"
+
+@implementation UIViewController (DLRNavigationController)
+
+- (UINavigationController *)dlr_embedInsideNavigationController {
+    return [[UINavigationController alloc] initWithRootViewController:self];
+}
+
+@end

--- a/DLRUIKitTests/source/UIDevice+DLRTests.m
+++ b/DLRUIKitTests/source/UIDevice+DLRTests.m
@@ -10,7 +10,7 @@
 
 #import "UIDevice+DLR.h"
 
-@interface UIDevice (DLRPrivate)
+@interface UIDevice (UIDevice_DLRTests)
 
 + (BOOL)dlr_isSystemVersion:(NSString *)systemVersion equalToVersion:(NSString *)version;
 + (BOOL)dlr_isSystemVersion:(NSString *)systemVersion greaterThanVersion:(NSString *)version;

--- a/DLRUIKitTests/source/UINavigationController+DLRTests.m
+++ b/DLRUIKitTests/source/UINavigationController+DLRTests.m
@@ -1,0 +1,47 @@
+//
+//  UINavigationController+DLRTests.m
+//  DLRUIKit
+//
+//  Created by Nate Walczak on 4/29/15.
+//  Copyright (c) 2015 Detroit Labs, LLC. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "UINavigationController+DLR.h"
+
+@interface UINavigationController_DLRTests : XCTestCase
+
+@end
+
+@implementation UINavigationController_DLRTests
+
+#pragma mark - dlr_isFirstViewController:
+
+- (void)testIsFirstViewController {
+    UIViewController *viewController = [[UIViewController alloc] init];
+    
+    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
+    
+    XCTAssertEqual(navigationController.viewControllers.count, 1);
+    XCTAssertEqual(navigationController.viewControllers.firstObject, viewController);
+    
+    XCTAssertTrue([navigationController dlr_isFirstViewController:viewController]);
+}
+
+- (void)testIsFirstViewControllerNot {
+    UIViewController *firstViewController = [[UIViewController alloc] init];
+    
+    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:firstViewController];
+    
+    UIViewController *secondViewController = [[UIViewController alloc] init];
+    [navigationController pushViewController:secondViewController animated:NO];
+    
+    XCTAssertEqual(navigationController.viewControllers.count, 2);
+    XCTAssertEqual(navigationController.viewControllers[0], firstViewController);
+    XCTAssertEqual(navigationController.viewControllers[1], secondViewController);
+    
+    XCTAssertFalse([navigationController dlr_isFirstViewController:secondViewController]);
+}
+
+@end

--- a/DLRUIKitTests/source/UIViewController+DLRNavigationControllerTests.m
+++ b/DLRUIKitTests/source/UIViewController+DLRNavigationControllerTests.m
@@ -1,0 +1,30 @@
+//
+//  UIViewController+DLRNavigationControllerTests.m
+//  DLRUIKit
+//
+//  Created by Nate Walczak on 4/29/15.
+//  Copyright (c) 2015 Detroit Labs, LLC. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "UIViewController+DLRNavigationController.h"
+
+@interface UIViewController_DLRNavigationControllerTests : XCTestCase
+
+@end
+
+@implementation UIViewController_DLRNavigationControllerTests
+
+#pragma mark - dlr_embedInsideNavigationController
+
+- (void)testEmbedInsideNavigationController {
+    UIViewController *viewController = [[UIViewController alloc] init];
+    
+    UINavigationController *navigationController = [viewController dlr_embedInsideNavigationController];
+    
+    XCTAssertEqual(navigationController.viewControllers.count, 1);
+    XCTAssertEqual(navigationController.viewControllers.firstObject, viewController);
+}
+
+@end

--- a/DLRUIKitTests/source/UIViewController+DLRParentViewControllerTests.m
+++ b/DLRUIKitTests/source/UIViewController+DLRParentViewControllerTests.m
@@ -10,11 +10,11 @@
 
 #import "UIViewController+DLRParentViewController.h"
 
-@interface DLRParentViewControllerTests : XCTestCase
+@interface UIViewController_DLRParentViewControllerTests : XCTestCase
 
 @end
 
-@implementation DLRParentViewControllerTests
+@implementation UIViewController_DLRParentViewControllerTests
 
 #pragma mark - dlr_addToParentViewController:
 

--- a/README.md
+++ b/README.md
@@ -172,3 +172,17 @@ layoutConstraint.constant = -10;
 // resets layoutConstraint.constant back to 50
 [layoutConstraint dlr_applyInitialConstant];
 ```
+
+### UINavigationController+DLR Category Examples
+
+```objc
+/** Returns true if the passed view controller is the first view controller in the stack of view controllers. */
+- (BOOL)dlr_isFirstViewController:(UIViewController *)viewController;
+```
+
+### UIViewController+DLRNavigationController Category Examples
+
+```objc
+/** Returns a new navigation controller instance with this view controller as the root view controller. */
+- (UINavigationController *)dlr_embedInsideNavigationController;
+```

--- a/README.md
+++ b/README.md
@@ -176,13 +176,15 @@ layoutConstraint.constant = -10;
 ### UINavigationController+DLR Category Examples
 
 ```objc
-/** Returns true if the passed view controller is the first view controller in the stack of view controllers. */
+/** Returns true if the passed view controller is the first view controller in the
+    stack of view controllers. */
 - (BOOL)dlr_isFirstViewController:(UIViewController *)viewController;
 ```
 
 ### UIViewController+DLRNavigationController Category Examples
 
 ```objc
-/** Returns a new navigation controller instance with this view controller as the root view controller. */
+/** Returns a new navigation controller instance with this view controller as the
+    root view controller. */
 - (UINavigationController *)dlr_embedInsideNavigationController;
 ```

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ layoutConstraint.constant = -10;
 
 ```objc
 /** Returns true if the passed view controller is the first view controller in the
-    stack of view controllers. */
+ stack of view controllers.  This can be helpful in determining if the
+ view controller needed to be popped or dismissed. */
 - (BOOL)dlr_isFirstViewController:(UIViewController *)viewController;
 ```
 
@@ -185,6 +186,6 @@ layoutConstraint.constant = -10;
 
 ```objc
 /** Returns a new navigation controller instance with this view controller as the
-    root view controller. */
+ root view controller. */
 - (UINavigationController *)dlr_embedInsideNavigationController;
 ```


### PR DESCRIPTION
### UINavigationController+DLR Category Examples

```objc
/** Returns true if the passed view controller is the first view controller in the
    stack of view controllers. */
- (BOOL)dlr_isFirstViewController:(UIViewController *)viewController;
```

### UIViewController+DLRNavigationController Category Examples

```objc
/** Returns a new navigation controller instance with this view controller as the
    root view controller. */
- (UINavigationController *)dlr_embedInsideNavigationController;
```
