### PR TITLE
Switch UIWebViews to WKWebViews

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ language: objective-c
 
 script:
   # TODO Add 'test' flag here once tests work on travis-ci server.
-  - xctool build -project DLRUIKit.xcodeproj -scheme DLRUIKitExampleApp -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO
+  - xcodebuild -project DLRUIKit.xcodeproj -scheme DLRUIKitExampleApp -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO

--- a/DLRUIKit/source/UIWebView+DLRViewport.h
+++ b/DLRUIKit/source/UIWebView+DLRViewport.h
@@ -6,9 +6,9 @@
 //  Copyright (c) 2014 Detroit Labs, LLC. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
 
-@interface UIWebView (DLRViewport)
+@interface WKWebView (DLRViewport)
 
 - (void)dlr_addViewport;
 

--- a/DLRUIKit/source/UIWebView+DLRViewport.m
+++ b/DLRUIKit/source/UIWebView+DLRViewport.m
@@ -19,7 +19,6 @@
     @"var head = document.getElementsByTagName('head')[0];"
     @"head.appendChild(element);"
     @"}";
-    
     [self evaluateJavaScript:script completionHandler:nil];
 }
 

--- a/DLRUIKit/source/UIWebView+DLRViewport.m
+++ b/DLRUIKit/source/UIWebView+DLRViewport.m
@@ -8,7 +8,7 @@
 
 #import "UIWebView+DLRViewport.h"
 
-@implementation UIWebView (DLRViewport)
+@implementation WKWebView (DLRViewport)
 
 - (void)dlr_addViewport {
     NSString *script =
@@ -19,7 +19,8 @@
     @"var head = document.getElementsByTagName('head')[0];"
     @"head.appendChild(element);"
     @"}";
-    [self stringByEvaluatingJavaScriptFromString:script];
+    
+    [self evaluateJavaScript:script completionHandler:nil];
 }
 
 @end

--- a/DLRUIKitTests/source/UIWebView+DLRViewportTests.m
+++ b/DLRUIKitTests/source/UIWebView+DLRViewportTests.m
@@ -19,7 +19,7 @@
 #pragma mark - dlr_resetLocalNotifications
 
 - (void)testResetLocalNotifications {
-    UIWebView *webView = [[UIWebView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, 320.0f, 480.0f)];
+    WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, 320.0f, 480.0f)];
     
     [webView dlr_addViewport];
 }


### PR DESCRIPTION
## What Does This Do?
This replaces the UIWebViews in the DLRViewport with WKWebViews

## Why Does It Do it?
Apple is deprecating UIWebView, and having users move over to WebKit instead. Apps will not be able to be submitted to the App Store post Dec 2020 if they continue to use UIWebView. 

## How do I test It?
Existing Unit Tests were updated to conform to new API. Any App that uses a DLRViewport should test that the existing functionality remains the same.